### PR TITLE
Feature/sw precache

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 This starter-kyt should serve as the base for an advanced, server and client-rendered React Redux app. It is based on NYT's Universal React starter-kyt but with the addition of some tools we found useful, most importantly the addition of Redux, Redux-Thunks and Async data loading on the server.
 
-## Installation
+It is assumed you know what [kyt](https://github.com/NYTimes/kyt) is and why you should use it.
 
-Create a new directory and install [kyt](https://github.com/NYTimes/kyt)
+## Installation
 
 1. `git init`
 2. `npm init`
 3. `npm install --save kyt@0.3.0`
-4. `node_modules/.bin/kyt setup -r git@bitbucket.org:cleverfranke/cf-kyt-starter-universal-redux.git#feature/sw-precache`
+4. `node_modules/.bin/kyt setup -r git@bitbucket.org:cleverfranke/cf-kyt-starter-universal-redux.git`
 5. `npm run dev` and start hacking away
 
 ## Tools

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Create a new directory and install [kyt](https://github.com/NYTimes/kyt)
 1. `git init`
 2. `npm init`
 3. `npm install --save kyt@0.3.0`
-4. `node_modules/.bin/kyt setup -r git@bitbucket.org:cleverfranke/cf-kyt-starter-universal-redux.git`
+4. `node_modules/.bin/kyt setup -r git@bitbucket.org:cleverfranke/cf-kyt-starter-universal-redux.git#feature/sw-precache`
 5. `npm run dev` and start hacking away
 
 ## Tools
@@ -33,14 +33,10 @@ The libraries listed here are not present by default in the NYT React Universal 
 - [Perf Addons](https://www.npmjs.com/package/react-addons-perf) - React Perf Addons for easy debugging of your web applications performance. We recommend using something like the [React Perf extension](https://chrome.google.com/webstore/detail/react-perf/hacmcodfllhbnekmghgdlplbdnahmhmm) to hook into the Perf Addons and perform your tests.
 
 ## Architecture changes
-We've modified the Express configuration to return 404 status codes when showing a 404 NotFound component. We also modified the configuration to detect Async methods on route components and delay returning HTML until the promise is resolved and optionally the store is populated with the response of these Async requests.
-
-## Notes on implementation
-
-- As a performance optimization, React Router routes are loaded dynamically and chunked separately using the ES2015 `System.import` directive. See more about  [Webpack 2 support](https://gist.github.com/sokra/27b24881210b56bbaff7#code-splitting-with-es6) and [dynamic routing](https://github.com/reactjs/react-router/blob/master/docs/guides/DynamicRouting.md).
-
-## How To Contribute
-Want to build your own starter-kyt?
-See directions [here](https://github.com/NYTimes/kyt/blob/master/docs/Starterkyts.md).
+- We modified the Express configuration to return 404 status codes when showing a 404 NotFound component.
+- We modified the Express configuration to detect Async methods on route components and delay returning HTML until the promise is resolved and optionally the store is populated with the response of these Async requests.
+- We modified the build scripts to automatically generate a service worker file with the help of sw-precache
 
 ## Changelog
+- 1.1.0 - Adding Service Worker support
+- 1.0.0 - First release

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "cf-kyt-starter-universal-redux",
-  "version": "1.0.0",
-  "description": "",
+  "version": "1.1.0",
+  "description": "A starter kyt with React, Redux, SSR and data fetching.",
   "main": "index.js",
   "scripts": {
+    "build": "kyt build && sw-precache --config=sw-precache-config.js",
   },
   "repository": {
     "type": "git",
@@ -17,7 +18,8 @@
   "homepage": "https://github.com/cleverfranke/cf-kyt-starter-universal-redux#readme",
   "kyt": {
     "version": "^0.3.0",
-    "files": [".eslintrc.json"]
+    "files": [".eslintrc.json", "sw-precache-config.js"],
+    "scripts": ["build"]
   },
   "dependencies": {
     "babel-eslint": "^6.1.2",
@@ -39,6 +41,7 @@
     "redux-devtools": "^3.3.1",
     "redux-devtools-dock-monitor": "^1.1.1",
     "redux-devtools-log-monitor": "^1.1.1",
-    "redux-thunk": "^2.1.0"
+    "redux-thunk": "^2.1.0",
+    "sw-precache": "^4.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A starter kyt with React, Redux, SSR and data fetching.",
   "main": "index.js",
   "scripts": {
-    "build": "kyt build && sw-precache --config=sw-precache-config.js",
+    "build": "kyt build && sw-precache --config=sw-precache-config.js"
   },
   "repository": {
     "type": "git",

--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -1,0 +1,13 @@
+{
+  "short_name": "create-react-pwa",
+  "name": "Create React PWApp",
+  "icons": [
+    {
+      "src": "favicon.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "./",
+  "display": "standalone"
+}

--- a/src/public/manifest.json
+++ b/src/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "create-react-pwa",
-  "name": "Create React PWApp",
+  "short_name": "cf-starter-kyt",
+  "name": "C°F Universal React Starter Kyt",
   "icons": [
     {
       "src": "favicon.png",

--- a/src/server/template.js
+++ b/src/server/template.js
@@ -16,6 +16,7 @@ export default (vo) => {
         ${head.meta.toString()}
         ${head.link.toString()}
         <link id="favicon" rel="shortcut icon" href="/favicon.png" sizes="16x16 32x32" type="image/png" />
+        <link rel="manifest" href="manifest.json">
         ${vo.cssBundle ? '<link rel="stylesheet" type="text/css" href="' + vo.cssBundle + '">' : ''}
       </head>
       <body>

--- a/sw-precache-config.js
+++ b/sw-precache-config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  stripPrefix: 'build/public/',
+  staticFileGlobs: [
+    'build/*.html',
+    'build/public/manifest.json',
+    'build/public/**/!(*map*)',
+  ],
+  dontCacheBustUrlsMatching: /\.\w{8}\./,
+  swFilePath: 'build/public/service-worker.js',
+  navigateFallback: '/',
+};


### PR DESCRIPTION
Adds in sw-precache to automatically generate a service-worker file. Also adds in a manifest file for completeness. Routes are not caches yet by the service worker configuration, which is something I would like to see happen soon.