### PR TITLE
Moved classNames.bind outside component

### DIFF
--- a/src/components/Count/index.js
+++ b/src/components/Count/index.js
@@ -9,8 +9,9 @@ import classNames from 'classnames/bind';
 import styles from './styles.scss';
 import { shouldIncrement, promiseIncrement } from '../../redux/reducers/modules/counter';
 
+const cx = classNames.bind(styles);
+
 export function Count(props) {
-  const cx = classNames.bind(styles);
   const asyncButtonClass = cx({
     countButton: true,
     inProgress: props.promisePending,


### PR DESCRIPTION
In order to create a better example on how to use `classNames.bind(styles)` I moved classNames.bind outside the component because this method will break once the function is changed into a class.